### PR TITLE
Call SetActive before BroadcastMessage on marker found.

### DIFF
--- a/src/Unity/Assets/ARToolKit5-Unity/Scripts/ARTrackedObject.cs
+++ b/src/Unity/Assets/ARToolKit5-Unity/Scripts/ARTrackedObject.cs
@@ -145,9 +145,8 @@ public class ARTrackedObject : MonoBehaviour
 						if (!visible) {
 							// Marker was hidden but now is visible.
 							visible = visibleOrRemain = true;
-							if (eventReceiver != null) eventReceiver.BroadcastMessage("OnMarkerFound", marker, SendMessageOptions.DontRequireReceiver);
-
 							for (int i = 0; i < this.transform.childCount; i++) this.transform.GetChild(i).gameObject.SetActive(true);
+							if (eventReceiver != null) eventReceiver.BroadcastMessage("OnMarkerFound", marker, SendMessageOptions.DontRequireReceiver);
 						}
 
                         Matrix4x4 pose;


### PR DESCRIPTION
In the event that the eventReceiver is the child object of 'Marker scene', and BroadcastMessage is called before the for-loop, then the method OnMarkerFound will never actually be called. BroadcastMessage has been moved to after the for-loop.
